### PR TITLE
Update BarSkeletonDoc.java

### DIFF
--- a/common/common-core/src/main/java/com/iohao/game/action/skeleton/core/doc/BarSkeletonDoc.java
+++ b/common/common-core/src/main/java/com/iohao/game/action/skeleton/core/doc/BarSkeletonDoc.java
@@ -46,7 +46,7 @@ public class BarSkeletonDoc {
 
     public void buildDoc() {
         // 路径为当前项目
-        String docPath = System.getProperty("user.idr") + File.separator + docFileName;
+        String docPath = System.getProperty("user.dir") + File.separator + docFileName;
 
         this.buildDoc(docPath);
     }


### PR DESCRIPTION
修复生成文档时，读取默认路径user.dir的拼写问题。