### PR TITLE
增加protobuf枚举类支持自定义value.

### DIFF
--- a/widget/light-jprotobuf/src/main/java/com/iohao/game/widget/light/protobuf/ProtoJavaField.java
+++ b/widget/light-jprotobuf/src/main/java/com/iohao/game/widget/light/protobuf/ProtoJavaField.java
@@ -18,6 +18,7 @@
  */
 package com.iohao.game.widget.light.protobuf;
 
+import com.baidu.bjf.remoting.protobuf.EnumReadable;
 import com.iohao.game.common.kit.StrKit;
 import com.iohao.game.widget.light.protobuf.kit.GenerateFileKit;
 import lombok.AccessLevel;
@@ -27,6 +28,7 @@ import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +82,11 @@ public class ProtoJavaField {
     }
 
     public String toProtoFieldLine() {
+        boolean isEnum = this.protoJavaParent.getClazz().isEnum();
+        if(isEnum){
+            this.resetEnumOrder();
+        }
+
         Map<String, String> messageMap = this.createParam();
 
         String templateFiled = getTemplateFiled(this.protoJavaParent.getClazz().isEnum());
@@ -109,5 +116,26 @@ public class ProtoJavaField {
         }
 
         return templateFiled.toString();
+    }
+
+
+    private void resetEnumOrder(){
+        if(EnumReadable.class.isAssignableFrom(fieldTypeClass)){
+            try {
+                Enum[] enumConstants = (Enum[])fieldTypeClass.getEnumConstants();
+
+                Method getValueMethod = fieldTypeClass.getMethod("value");
+
+                for (Enum constant : enumConstants) {
+                    String constantName = constant.name();
+                    if (constantName.equals(fieldName)) {
+                        this.order = (int) getValueMethod.invoke(constant);
+                        return ;
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/widget/light-jprotobuf/src/test/java/com/iohao/game/widget/light/protobuf/vo/TestEnumCustom.java
+++ b/widget/light-jprotobuf/src/test/java/com/iohao/game/widget/light/protobuf/vo/TestEnumCustom.java
@@ -1,0 +1,41 @@
+package com.iohao.game.widget.light.protobuf.vo;
+
+import com.baidu.bjf.remoting.protobuf.EnumReadable;
+import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
+import com.iohao.game.widget.light.protobuf.ProtoFileMerge;
+import lombok.AccessLevel;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 测试生成一个TestEnum
+ */
+@ProtobufClass
+@FieldDefaults(level = AccessLevel.PUBLIC)
+@ToString
+@ProtoFileMerge(fileName = "testEnum.proto", filePackage = "com.iohao.game.widget.light.protobuf.vo")
+public enum TestEnumCustom implements EnumReadable {
+
+    AS(0),
+    /**
+     * AC
+     */
+    AC(1001),
+    /**
+     * BC
+     */
+    BC(1002),
+    ;
+
+    private int value;
+
+    TestEnumCustom(int value){
+        this.value = value;
+    }
+
+
+    @Override
+    public int value() {
+        return value;
+    }
+}


### PR DESCRIPTION
增加protobuf枚举类支持自定义value.
比如Channel：XIAOMI,OPPO,....
这种可能，其它地方已经定义好了。需要保持统一。
```
enum Channel {
  PC= 0;
  XIAOMI = 1001;
  OPPO = 1002;
  HW = 1003;
}

写法上需要：
/**
 * 测试生成一个TestEnum
 */
@ProtobufClass
@FieldDefaults(level = AccessLevel.PUBLIC)
@ToString
@ProtoFileMerge(fileName = "testEnum.proto", filePackage = "com.iohao.game.widget.light.protobuf.vo")
public enum Channel implements EnumReadable {
    PC(0),
     XIAOMI(1001),
     OPPO(1002),
     HW(10023),
    ;

    private int value;

    TestEnumCustom(int value){
        this.value = value;
    }


    @Override
    public int value() {
        return value;
    }
```
