### PR TITLE
fix(protobuf): handle same package proto type reference

### DIFF
--- a/widget/light-jprotobuf/src/main/java/com/iohao/game/widget/light/protobuf/ProtoJavaAnalyse.java
+++ b/widget/light-jprotobuf/src/main/java/com/iohao/game/widget/light/protobuf/ProtoJavaAnalyse.java
@@ -209,8 +209,13 @@ public class ProtoJavaAnalyse {
             ProtoJavaRegionKey regionKey = protoJavaParent.getProtoJavaRegionKey();
             ProtoJavaRegion protoJavaRegion = this.getProtoJavaRegion(regionKey);
             protoJavaRegion.addOtherProtoFile(protoJavaFieldType);
-            // 不在同一个文件中
-            fieldProtoType = StrKit.format("{}.{}", filePackage, className);
+            if (Objects.equals(protoJavaParent.getFilePackage(), filePackage)) {
+                // 不在同一个文件夹，但是在同一个包下
+                fieldProtoType = className;
+            } else {
+                // 不在同一个文件中
+                fieldProtoType = StrKit.format("{}.{}", filePackage, className);
+            }
         }
 
         return fieldProtoType;


### PR DESCRIPTION
修复同一个包名，但是在不同的 proto 文件的字段类型问题，相同的包名会导致生成的 proto 文件报错